### PR TITLE
added ENV VAR to frontend to avoid raise exception due to newer versi…

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-slim
 
+ENV GIT_PYTHON_REFRESH=quiet
 WORKDIR /app
 
 COPY requirements.txt .


### PR DESCRIPTION
Updated streamlit library required either git to be installed or environment variable GIT_PYTHON_REFRESH=quiet to be set.

I have just added this line so that I can get the code working. 
Also, checked streamlit repo for the same issue. seems like someone is working on it.

If possible, will also check the difference between using the warning and installing git soon.
for now, I was able to get this working using the above change.